### PR TITLE
move to async validators

### DIFF
--- a/projects/validator/src/public-api.ts
+++ b/projects/validator/src/public-api.ts
@@ -21,5 +21,5 @@ export type ValidationId = string
 
 
 export interface Validator {
-    (data:Model,id:ValidationId) : ValidationErrors
+    (data:Model,id:ValidationId) : Promise<ValidationErrors>
 }


### PR DESCRIPTION
Making async validators mandatory, gives us a possibility to do API calls and other async stuff in the validator. 
I think dat we need a best practice that splits out long running validators in a separate validator?