### PR TITLE
refactor: use a builder for testing with jest in favor of manual conf…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,6 +23,12 @@
             }
           },
           "defaultConfiguration": "production"
+        },
+        "test": {
+          "builder": "@angular-builders/jest:run",
+          "options": {
+            "passWithNoTests": true
+          }
         }
       }
     },
@@ -103,6 +109,12 @@
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
             "browserTarget": "demo:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-builders/jest:run",
+          "options": {
+            "passWithNoTests": true
           }
         }
       }

--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-    preset: 'jest-preset-angular',
-    setupFilesAfterEnv: ['<rootDir>/../../jest.base.setup.ts']
-  };

--- a/jest.base.setup.ts
+++ b/jest.base.setup.ts
@@ -1,1 +1,0 @@
-import 'jest-preset-angular/setup-jest';

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
+        "@angular-builders/jest": "^14.0.0",
         "@angular-devkit/build-angular": "^14.1.1",
         "@angular/cli": "^14.1.1",
         "@angular/compiler-cli": "^14.1.1",
@@ -48,6 +49,55 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@angular-builders/jest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-builders/jest/-/jest-14.0.0.tgz",
+      "integrity": "sha512-FBcbEmrCJqlA6lDVW7BzcPq2zQ98UNua0IO6DxHEi9LN/5Yyx2YJSbYqmfykyRBEnIqLzHVGOX9eBIiSg0Bc/w==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/architect": ">=0.1400.0 < 0.1500.0",
+        "@angular-devkit/core": "^14.0.0",
+        "jest-preset-angular": "12.1.0",
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.10.0"
+      },
+      "peerDependencies": {
+        "@angular-devkit/build-angular": "^14.0.0",
+        "@angular/compiler-cli": "^14.0.0",
+        "@angular/core": "^14.0.0",
+        "@angular/platform-browser-dynamic": "^14.0.0",
+        "jest": ">=28"
+      }
+    },
+    "node_modules/@angular-builders/jest/node_modules/jest-preset-angular": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-12.1.0.tgz",
+      "integrity": "sha512-zOiUvAMqIYkr8yRRO9x2NwVD8rzx0GtDaWxxox5GdgFQ/EEeIMI2Wqf5gfuX0t3Cnrq+K6cJCr181VMrjPkLPA==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "esbuild-wasm": ">=0.13.8",
+        "jest-environment-jsdom": "^28.0.0",
+        "pretty-format": "^28.0.0",
+        "ts-jest": "^28.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.10.0"
+      },
+      "optionalDependencies": {
+        "esbuild": ">=0.13.8"
+      },
+      "peerDependencies": {
+        "@angular-devkit/build-angular": ">=0.1102.19 <15.0.0",
+        "@angular/compiler-cli": ">=11.2.14 <15.0.0",
+        "@angular/core": ">=11.2.14 <15.0.0",
+        "@angular/platform-browser-dynamic": ">=11.2.14 <15.0.0",
+        "jest": "^28.0.0",
+        "typescript": ">=4.3"
       }
     },
     "node_modules/@angular-devkit/architect": {
@@ -16142,6 +16192,34 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@angular-builders/jest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-builders/jest/-/jest-14.0.0.tgz",
+      "integrity": "sha512-FBcbEmrCJqlA6lDVW7BzcPq2zQ98UNua0IO6DxHEi9LN/5Yyx2YJSbYqmfykyRBEnIqLzHVGOX9eBIiSg0Bc/w==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/architect": ">=0.1400.0 < 0.1500.0",
+        "@angular-devkit/core": "^14.0.0",
+        "jest-preset-angular": "12.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "jest-preset-angular": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-12.1.0.tgz",
+          "integrity": "sha512-zOiUvAMqIYkr8yRRO9x2NwVD8rzx0GtDaWxxox5GdgFQ/EEeIMI2Wqf5gfuX0t3Cnrq+K6cJCr181VMrjPkLPA==",
+          "dev": true,
+          "requires": {
+            "bs-logger": "^0.2.6",
+            "esbuild": ">=0.13.8",
+            "esbuild-wasm": ">=0.13.8",
+            "jest-environment-jsdom": "^28.0.0",
+            "pretty-format": "^28.0.0",
+            "ts-jest": "^28.0.0"
+          }
+        }
       }
     },
     "@angular-devkit/architect": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test:lib": "jest --config --passWithNoTests ./projects/validator/jest.config.js",
-    "test:app": "jest --config --passWithNoTests ./projects/demo/jest.config.js",
+    "test:lib": "npx ng test --project validator",
+    "test:app": "npx ng test --project demo",
     "test": "npm run test:lib && npm run test:app"
   },
   "private": true,
@@ -26,6 +26,7 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
+    "@angular-builders/jest": "^14.0.0",
     "@angular-devkit/build-angular": "^14.1.1",
     "@angular/cli": "^14.1.1",
     "@angular/compiler-cli": "^14.1.1",

--- a/projects/demo/jest.config.js
+++ b/projects/demo/jest.config.js
@@ -1,4 +1,0 @@
-const baseConfig = require('../../jest.base.config');
-module.exports = {
-  ...baseConfig,
-};

--- a/projects/validator/jest.config.js
+++ b/projects/validator/jest.config.js
@@ -1,4 +1,0 @@
-const baseConfig = require('../../jest.base.config');
-module.exports = {
-  ...baseConfig,
-};

--- a/projects/validator/tsconfig.spec.json
+++ b/projects/validator/tsconfig.spec.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "emitDecoratorMetadata":true,
     "outDir": "../../out-tsc/spec",
+    "module": "CommonJs",
     "types": [
       "jest",
       "node"


### PR DESCRIPTION
Update our setting to use a custom jest builder in favor of the manual configuration. In case we need specific configuration for jest we can easily create a custom config and this will be used by the builder.